### PR TITLE
[공통] WebConfig 전체 접근 허용

### DIFF
--- a/src/main/java/com/toucheese/global/config/WebConfig.java
+++ b/src/main/java/com/toucheese/global/config/WebConfig.java
@@ -10,9 +10,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("*")
+                .allowedOrigins("*")
                 .allowedMethods("*")
                 .allowedHeaders("*")
-                .allowCredentials(true);
+                .allowCredentials(false);
     }
 }


### PR DESCRIPTION
- close #18 
### - 작업목록
- [x] allowedPattens -> allowedOrigins
- [x] allowCredentials(false)

### 참고사항
- allowCredentials(true)와 allowedOrigins("*") 동시 사용 불가능

### 예정사항
- 추후 allowedPattens("https://*.exmple.com:3000")과 같은 형식으로 사용
-> allowCredentials(true)를 함께 사용하여 보안 기능 향상 