### PR TITLE
[Image] 이미지 업로드 기능 리팩토링

### DIFF
--- a/src/main/java/com/toucheese/admin/service/AdminAnswerService.java
+++ b/src/main/java/com/toucheese/admin/service/AdminAnswerService.java
@@ -1,28 +1,26 @@
 package com.toucheese.admin.service;
 
+import com.toucheese.global.config.ImageConfig;
 import com.toucheese.global.exception.ToucheeseBadRequestException;
 import com.toucheese.global.util.PageUtils;
-import com.toucheese.question.dto.AnswerResponse;
 import com.toucheese.question.dto.QuestionResponse;
 import com.toucheese.question.entity.Answer;
-import com.toucheese.question.entity.AnswerStatus;
 import com.toucheese.question.entity.Question;
 import com.toucheese.question.repository.AnswerRepository;
 import com.toucheese.question.repository.QuestionRepository;
 import com.toucheese.question.service.QuestionReadService;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.security.Principal;
-import java.time.LocalDate;
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class AdminAnswerService {
+
+    private final ImageConfig imageConfig;
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
     private final QuestionReadService questionReadService;
@@ -35,19 +33,21 @@ public class AdminAnswerService {
     @Transactional(readOnly = true)
     public Page<QuestionResponse> getAllQuestions(int page) {
         Pageable pageable = PageUtils.createPageable(page);
+
         Page<Question> questions = questionRepository.findAll(pageable);
-        return questions.map(QuestionResponse::of);
+        return questions.map(question ->
+                QuestionResponse.of(question, imageConfig.getResizedImageBaseUrl())
+        );
     }
 
     @Transactional(readOnly = true)
     public QuestionResponse getQuestionById(Long questionId) {
         Question question = questionReadService.findQuestionById(questionId);
-        return QuestionResponse.of(question);
+        return QuestionResponse.of(question, imageConfig.getResizedImageBaseUrl());
     }
 
     @Transactional
     public void addAnswer(Long questionId, String content) {
-
         Question question = questionReadService.findQuestionById(questionId);
 
         Answer answer = answerRepository.save(

--- a/src/main/java/com/toucheese/image/controller/ImageController.java
+++ b/src/main/java/com/toucheese/image/controller/ImageController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -40,11 +41,11 @@ public class ImageController {
      * @param uploadFiles 업로드 요청 파일 목록
      * @param studioId 스튜디오 ID
      */
-    @PostMapping("/v2/studios/images")
+    @PostMapping("/v2/studios/{studioId}/images")
     @Operation(summary = "스튜디오 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
     public void studioImageUpload(
             @RequestPart List<MultipartFile> uploadFiles,
-            @RequestParam Long studioId
+            @PathVariable Long studioId
     ) {
         imageService.uploadImageWithDetails(uploadFiles, studioId, ImageType.STUDIO);
     }
@@ -54,11 +55,11 @@ public class ImageController {
      * @param uploadFiles 업로드 요청 파일 목록
      * @param reviewId 리뷰 ID
      */
-    @PostMapping("/v2/reviews/images")
+    @PostMapping("/v2/reviews/{reviewId}/images")
     @Operation(summary = "리뷰 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
     public void reviewImageUpload(
             @RequestPart List<MultipartFile> uploadFiles,
-            @RequestParam Long reviewId
+            @PathVariable Long reviewId
     ) {
         imageService.uploadImageWithDetails(uploadFiles, reviewId, ImageType.REVIEW);
     }
@@ -68,11 +69,11 @@ public class ImageController {
      * @param uploadFiles 업로드 요청 파일 목록
      * @param studioId 스튜디오 ID
      */
-    @PostMapping("/v2/facilities/images")
+    @PostMapping("/v2/facilities/{studioId}/images")
     @Operation(summary = "시설 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
     public void facilityImageUpload(
             @RequestPart List<MultipartFile> uploadFiles,
-            @RequestParam Long studioId
+            @PathVariable Long studioId
     ) {
         imageService.uploadImageWithDetails(uploadFiles, studioId, ImageType.FACILITY);
     }
@@ -82,11 +83,11 @@ public class ImageController {
      * @param uploadFiles 업로드 요청 파일 목록
      * @param questionId 문의 ID
      */
-    @PostMapping("/v2/questions/images")
+    @PostMapping("/v2/questions/{questionId}/images")
     @Operation(summary = "문의 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
     public void questionImageUpload(
             @RequestPart List<MultipartFile> uploadFiles,
-            @RequestParam Long questionId
+            @PathVariable Long questionId
     ) {
         imageService.uploadImageWithDetails(uploadFiles, questionId, ImageType.FACILITY);
     }

--- a/src/main/java/com/toucheese/image/controller/ImageController.java
+++ b/src/main/java/com/toucheese/image/controller/ImageController.java
@@ -8,7 +8,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,12 +44,13 @@ public class ImageController {
     @PostMapping("/v2/studios/images")
     @Operation(summary = "스튜디오 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
     public void streamStudioImageUpload(
-            HttpServletRequest request, @RequestParam String filename, @RequestParam Long studioId
+            @RequestPart List<MultipartFile> uploadFiles,
+            @RequestParam Long studioId
     ) {
-        imageService.uploadImageWithDetails(request, filename, studioId, ImageType.STUDIO);
+        imageService.uploadImageWithDetails(uploadFiles, studioId, ImageType.STUDIO);
     }
-
     /**
+
      * Stream 방식으로 리뷰 이미지 업로드
      * @param request 요청 정보 (InputStream, Metadata)
      * @param filename 파일이름
@@ -54,9 +59,10 @@ public class ImageController {
     @PostMapping("/v2/reviews/images")
     @Operation(summary = "리뷰 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
     public void streamReviewImageUpload(
-            HttpServletRequest request, @RequestParam String filename, @RequestParam Long reviewId
+            @RequestPart List<MultipartFile> uploadFiles,
+            @RequestParam Long reviewId
     ) {
-        imageService.uploadImageWithDetails(request, filename, reviewId, ImageType.REVIEW);
+        imageService.uploadImageWithDetails(uploadFiles, reviewId, ImageType.REVIEW);
     }
 
     /**
@@ -68,8 +74,9 @@ public class ImageController {
     @PostMapping("/v2/facilities/images")
     @Operation(summary = "시설 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
     public void streamFacilityImageUpload(
-            HttpServletRequest request, @RequestParam String filename, @RequestParam Long studioId
+            @RequestPart List<MultipartFile> uploadFiles,
+            @RequestParam Long studioId
     ) {
-        imageService.uploadImageWithDetails(request, filename, studioId, ImageType.FACILITY);
+        imageService.uploadImageWithDetails(uploadFiles, studioId, ImageType.FACILITY);
     }
 }

--- a/src/main/java/com/toucheese/image/controller/ImageController.java
+++ b/src/main/java/com/toucheese/image/controller/ImageController.java
@@ -89,6 +89,6 @@ public class ImageController {
             @RequestPart List<MultipartFile> uploadFiles,
             @PathVariable Long questionId
     ) {
-        imageService.uploadImageWithDetails(uploadFiles, questionId, ImageType.FACILITY);
+        imageService.uploadImageWithDetails(uploadFiles, questionId, ImageType.QUESTION);
     }
 }

--- a/src/main/java/com/toucheese/image/controller/ImageController.java
+++ b/src/main/java/com/toucheese/image/controller/ImageController.java
@@ -28,7 +28,7 @@ public class ImageController {
      */
     @PostMapping("/v1/images")
     @Operation(summary = "기존 이미지 업로드만을 위한 API", description = "이미 DB에 적재되어 있는 이미지를 업로드만 진행")
-    public void streamExistingImageUpload(
+    public void existingImageStreamUpload(
             HttpServletRequest request,
             @RequestParam String filename
     ) {
@@ -36,14 +36,13 @@ public class ImageController {
     }
 
     /**
-     * Stream 방식으로 스튜디오 이미지 업로드
-     * @param request 요청 정보 (InputStream, Metadata)
-     * @param filename 파일이름
+     * MultipartFile 방식으로 스튜디오 이미지 업로드
+     * @param uploadFiles 업로드 요청 파일 목록
      * @param studioId 스튜디오 ID
      */
     @PostMapping("/v2/studios/images")
     @Operation(summary = "스튜디오 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
-    public void streamStudioImageUpload(
+    public void studioImageUpload(
             @RequestPart List<MultipartFile> uploadFiles,
             @RequestParam Long studioId
     ) {
@@ -51,14 +50,13 @@ public class ImageController {
     }
     /**
 
-     * Stream 방식으로 리뷰 이미지 업로드
-     * @param request 요청 정보 (InputStream, Metadata)
-     * @param filename 파일이름
+     * MultipartFile 방식으로 리뷰 이미지 업로드
+     * @param uploadFiles 업로드 요청 파일 목록
      * @param reviewId 리뷰 ID
      */
     @PostMapping("/v2/reviews/images")
     @Operation(summary = "리뷰 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
-    public void streamReviewImageUpload(
+    public void reviewImageUpload(
             @RequestPart List<MultipartFile> uploadFiles,
             @RequestParam Long reviewId
     ) {
@@ -66,17 +64,30 @@ public class ImageController {
     }
 
     /**
-     * Stream 방식으로 리뷰 이미지 업로드
-     * @param request 요청 정보 (InputStream, Metadata)
-     * @param filename 파일이름
+     * MultipartFile 방식으로 리뷰 이미지 업로드
+     * @param uploadFiles 업로드 요청 파일 목록
      * @param studioId 스튜디오 ID
      */
     @PostMapping("/v2/facilities/images")
     @Operation(summary = "시설 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
-    public void streamFacilityImageUpload(
+    public void facilityImageUpload(
             @RequestPart List<MultipartFile> uploadFiles,
             @RequestParam Long studioId
     ) {
         imageService.uploadImageWithDetails(uploadFiles, studioId, ImageType.FACILITY);
+    }
+
+    /**
+     * MultipartFile 방식으로 리뷰 이미지 업로드
+     * @param uploadFiles 업로드 요청 파일 목록
+     * @param questionId 문의 ID
+     */
+    @PostMapping("/v2/questions/images")
+    @Operation(summary = "문의 이미지 업로드를 위한 API", description = "이미지 업로드 및 DB 내 데이터 적재")
+    public void questionImageUpload(
+            @RequestPart List<MultipartFile> uploadFiles,
+            @RequestParam Long questionId
+    ) {
+        imageService.uploadImageWithDetails(uploadFiles, questionId, ImageType.FACILITY);
     }
 }

--- a/src/main/java/com/toucheese/image/entity/FacilityImage.java
+++ b/src/main/java/com/toucheese/image/entity/FacilityImage.java
@@ -26,7 +26,7 @@ public class FacilityImage {
 	@Column(nullable = false)
 	private String resizedPath;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "image_info_id")
 	private ImageInfo imageInfo;
 

--- a/src/main/java/com/toucheese/image/entity/FacilityImage.java
+++ b/src/main/java/com/toucheese/image/entity/FacilityImage.java
@@ -2,14 +2,7 @@ package com.toucheese.image.entity;
 
 import com.toucheese.studio.entity.Studio;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,23 +21,20 @@ public class FacilityImage {
 	private Studio studio;
 
 	@Column(nullable = false)
-	private String filename;
-
-	@Column(nullable = false)
-	private String uploadFilename;
-
-	@Column(nullable = false)
 	private String originalPath;
 
 	@Column(nullable = false)
 	private String resizedPath;
 
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "image_info_id")
+	private ImageInfo imageInfo;
+
 	@Builder
-	public FacilityImage(Studio studio, String filename, String uploadFilename, String originalPath, String resizedPath) {
+	public FacilityImage(Studio studio, String originalPath, String resizedPath, ImageInfo imageInfo) {
 		this.studio = studio;
-		this.filename = filename;
-		this.uploadFilename = uploadFilename;
 		this.originalPath = originalPath;
 		this.resizedPath = resizedPath;
+		this.imageInfo = imageInfo;
 	}
 }

--- a/src/main/java/com/toucheese/image/entity/ImageInfo.java
+++ b/src/main/java/com/toucheese/image/entity/ImageInfo.java
@@ -1,0 +1,28 @@
+package com.toucheese.image.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageInfo {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String filename;
+
+	@Column(nullable = false)
+	private String uploadFilename;
+
+	@Builder
+	public ImageInfo(String filename, String uploadFilename) {
+		this.filename = filename;
+		this.uploadFilename = uploadFilename;
+	}
+}

--- a/src/main/java/com/toucheese/image/entity/QuestionImage.java
+++ b/src/main/java/com/toucheese/image/entity/QuestionImage.java
@@ -25,7 +25,7 @@ public class QuestionImage {
     @Column(nullable = false)
     private String resizedPath;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_info_id")
     private ImageInfo imageInfo;
 

--- a/src/main/java/com/toucheese/image/entity/ReviewImage.java
+++ b/src/main/java/com/toucheese/image/entity/ReviewImage.java
@@ -26,7 +26,7 @@ public class ReviewImage {
 	@Column(nullable = false)
 	private String resizedPath;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "image_info_id")
 	private ImageInfo imageInfo;
 

--- a/src/main/java/com/toucheese/image/entity/ReviewImage.java
+++ b/src/main/java/com/toucheese/image/entity/ReviewImage.java
@@ -2,14 +2,7 @@ package com.toucheese.image.entity;
 
 import com.toucheese.review.entity.Review;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,23 +21,20 @@ public class ReviewImage {
 	private Review review;
 
 	@Column(nullable = false)
-	private String filename;
-
-	@Column(nullable = false)
-	private String uploadFilename;
-
-	@Column(nullable = false)
 	private String originalPath;
 
 	@Column(nullable = false)
 	private String resizedPath;
 
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "image_info_id")
+	private ImageInfo imageInfo;
+
 	@Builder
-	public ReviewImage(Review review, String filename, String uploadFilename, String originalPath, String resizedPath) {
+	public ReviewImage(Review review, String originalPath, String resizedPath, ImageInfo imageInfo) {
 		this.review = review;
-		this.filename = filename;
-		this.uploadFilename = uploadFilename;
 		this.originalPath = originalPath;
 		this.resizedPath = resizedPath;
+		this.imageInfo = imageInfo;
 	}
 }

--- a/src/main/java/com/toucheese/image/entity/StudioImage.java
+++ b/src/main/java/com/toucheese/image/entity/StudioImage.java
@@ -20,23 +20,21 @@ public class StudioImage {
     private Studio studio;
 
     @Column(nullable = false)
-    private String filename;
-
-    @Column(nullable = false)
-    private String uploadFilename;
-
-    @Column(nullable = false)
     private String originalPath;
 
     @Column(nullable = false)
     private String resizedPath;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_info_id")
+    private ImageInfo imageInfo;
+
     @Builder
-    public StudioImage(Studio studio, String filename, String uploadFilename, String originalPath, String resizedPath) {
+
+    public StudioImage(Studio studio, String originalPath, String resizedPath, ImageInfo imageInfo) {
         this.studio = studio;
-        this.filename = filename;
-        this.uploadFilename = uploadFilename;
         this.originalPath = originalPath;
         this.resizedPath = resizedPath;
+        this.imageInfo = imageInfo;
     }
 }

--- a/src/main/java/com/toucheese/image/entity/StudioImage.java
+++ b/src/main/java/com/toucheese/image/entity/StudioImage.java
@@ -25,7 +25,7 @@ public class StudioImage {
     @Column(nullable = false)
     private String resizedPath;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_info_id")
     private ImageInfo imageInfo;
 

--- a/src/main/java/com/toucheese/image/repository/FacilityImageRepository.java
+++ b/src/main/java/com/toucheese/image/repository/FacilityImageRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface FacilityImageRepository extends JpaRepository<FacilityImage, Long> {
-    Optional<FacilityImage> findByUploadFilename(String uploadFilename);
 }

--- a/src/main/java/com/toucheese/image/repository/ImageInfoRepository.java
+++ b/src/main/java/com/toucheese/image/repository/ImageInfoRepository.java
@@ -1,0 +1,10 @@
+package com.toucheese.image.repository;
+
+import com.toucheese.image.entity.ImageInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ImageInfoRepository extends JpaRepository<ImageInfo, Long> {
+    Optional<ImageInfo> findByUploadFilename(String uploadFilename);
+}

--- a/src/main/java/com/toucheese/image/repository/QuestionImageRepository.java
+++ b/src/main/java/com/toucheese/image/repository/QuestionImageRepository.java
@@ -3,8 +3,5 @@ package com.toucheese.image.repository;
 import com.toucheese.image.entity.QuestionImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface QuestionImageRepository extends JpaRepository<QuestionImage, Long> {
-    Optional<QuestionImage> findByUploadFilename(String uploadFilename);
 }

--- a/src/main/java/com/toucheese/image/repository/ReviewImageRepository.java
+++ b/src/main/java/com/toucheese/image/repository/ReviewImageRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
-    Optional<ReviewImage> findByUploadFilename(String uploadFilename);
 }

--- a/src/main/java/com/toucheese/image/repository/StudioImageRepository.java
+++ b/src/main/java/com/toucheese/image/repository/StudioImageRepository.java
@@ -6,6 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface StudioImageRepository extends JpaRepository<StudioImage, Long> {
-    Optional<StudioImage> findByUploadFilename(String uploadFilename);
-
 }

--- a/src/main/java/com/toucheese/image/service/ImageFacade.java
+++ b/src/main/java/com/toucheese/image/service/ImageFacade.java
@@ -36,6 +36,12 @@ public class ImageFacade {
 
     private static final String RESIZED_EXTENSION = ".webp";
 
+    /**
+     * 스튜디오 이미지 저장
+     * @param studioId 스튜디오 ID
+     * @param imageInfo 이미지 정보
+     * @param extension 기존 이미지에서 추출한 확장자
+     */
     @Transactional
     public void saveStudioImage(Long studioId, ImageInfo imageInfo, String extension) {
         Studio studio = studioService.findStudioById(studioId);
@@ -48,6 +54,12 @@ public class ImageFacade {
         studioImageRepository.save(studioImage);
     }
 
+    /**
+     * 리뷰 이미지 저장
+     * @param reviewId 리뷰 ID
+     * @param imageInfo 이미지 정보
+     * @param extension 기존 이미지에서 추출한 확장자
+     */
     @Transactional
     public void saveReviewImage(Long reviewId, ImageInfo imageInfo, String extension) {
         Review review = reviewService.findReviewById(reviewId);
@@ -60,6 +72,12 @@ public class ImageFacade {
         reviewImageRepository.save(reviewImage);
     }
 
+    /**
+     * 시설 이미지 저장
+     * @param studioId 스튜디오 ID
+     * @param imageInfo 이미지 정보
+     * @param extension 기존 이미지에서 추출한 확장자
+     */
     @Transactional
     public void saveFacilityImage(Long studioId, ImageInfo imageInfo, String extension) {
         Studio studio = studioService.findStudioById(studioId);
@@ -72,6 +90,12 @@ public class ImageFacade {
         facilityImageRepository.save(facilityImage);
     }
 
+    /**
+     * 문의 이미지 저장
+     * @param questionId 문의 ID
+     * @param imageInfo 이미지 정보
+     * @param extension 기존 이미지에서 추출한 확장자
+     */
     @Transactional
     public void saveQuestionImage(Long questionId, ImageInfo imageInfo, String extension) {
         Question question = questionReadService.findQuestionById(questionId);

--- a/src/main/java/com/toucheese/image/service/ImageFacade.java
+++ b/src/main/java/com/toucheese/image/service/ImageFacade.java
@@ -1,0 +1,87 @@
+package com.toucheese.image.service;
+
+import static com.toucheese.image.util.FilenameUtil.buildFilePath;
+
+import com.toucheese.image.entity.FacilityImage;
+import com.toucheese.image.entity.ImageInfo;
+import com.toucheese.image.entity.QuestionImage;
+import com.toucheese.image.entity.ReviewImage;
+import com.toucheese.image.entity.StudioImage;
+import com.toucheese.image.repository.FacilityImageRepository;
+import com.toucheese.image.repository.QuestionImageRepository;
+import com.toucheese.image.repository.ReviewImageRepository;
+import com.toucheese.image.repository.StudioImageRepository;
+import com.toucheese.question.entity.Question;
+import com.toucheese.question.service.QuestionReadService;
+import com.toucheese.review.entity.Review;
+import com.toucheese.review.service.ReviewService;
+import com.toucheese.studio.entity.Studio;
+import com.toucheese.studio.service.StudioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ImageFacade {
+
+    private final StudioService studioService;
+    private final ReviewService reviewService;
+    private final QuestionReadService questionReadService;
+
+    private final StudioImageRepository studioImageRepository;
+    private final ReviewImageRepository reviewImageRepository;
+    private final FacilityImageRepository facilityImageRepository;
+    private final QuestionImageRepository questionImageRepository;
+
+    private static final String RESIZED_EXTENSION = ".webp";
+
+    @Transactional
+    public void saveStudioImage(Long studioId, ImageInfo imageInfo, String extension) {
+        Studio studio = studioService.findStudioById(studioId);
+        StudioImage studioImage = StudioImage.builder()
+                .studio(studio)
+                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
+                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
+                .imageInfo(imageInfo)
+                .build();
+        studioImageRepository.save(studioImage);
+    }
+
+    @Transactional
+    public void saveReviewImage(Long reviewId, ImageInfo imageInfo, String extension) {
+        Review review = reviewService.findReviewById(reviewId);
+        ReviewImage reviewImage = ReviewImage.builder()
+                .review(review)
+                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
+                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
+                .imageInfo(imageInfo)
+                .build();
+        reviewImageRepository.save(reviewImage);
+    }
+
+    @Transactional
+    public void saveFacilityImage(Long studioId, ImageInfo imageInfo, String extension) {
+        Studio studio = studioService.findStudioById(studioId);
+        FacilityImage facilityImage = FacilityImage.builder()
+                .studio(studio)
+                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
+                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
+                .imageInfo(imageInfo)
+                .build();
+        facilityImageRepository.save(facilityImage);
+    }
+
+    @Transactional
+    public void saveQuestionImage(Long questionId, ImageInfo imageInfo, String extension) {
+        Question question = questionReadService.findQuestionById(questionId);
+        QuestionImage questionImage = QuestionImage.builder()
+                .question(question)
+                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
+                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
+                .imageInfo(imageInfo)
+                .build();
+        questionImageRepository.save(questionImage);
+    }
+
+}

--- a/src/main/java/com/toucheese/image/service/ImageInfoService.java
+++ b/src/main/java/com/toucheese/image/service/ImageInfoService.java
@@ -1,0 +1,54 @@
+package com.toucheese.image.service;
+
+import com.toucheese.image.entity.ImageInfo;
+import com.toucheese.image.repository.ImageInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.toucheese.image.util.FilenameUtil.generateRandomFileName;
+
+@Service
+@RequiredArgsConstructor
+public class ImageInfoService {
+
+    private final ImageInfoRepository imageInfoRepository;
+
+    /**
+     * 현재 이미지 파일 이름과 랜덤 생성된 파일 이름으로 이미지 정보 생성
+     * @param filename 현재 이미지 파일 이름
+     * @return 생성된 이미지 정보
+     */
+    @Transactional
+    public ImageInfo createImageInfo(String filename) {
+        return imageInfoRepository.save(
+                ImageInfo.builder()
+                        .filename(filename)
+                        .uploadFilename(generateRandomFilename())
+                        .build()
+        );
+    }
+
+    /**
+     * 파일 이름을 랜덤으로 생성하기 위한
+     * @return 생성된 파일 이름
+     */
+    private String generateRandomFilename() {
+        String randomFilename;
+
+        do {
+            randomFilename = generateRandomFileName();
+        } while (isFilenameExists(randomFilename));
+
+        return randomFilename;
+    }
+
+    /**
+     * 랜덤 생성된 파일 이름이 존재하는지 검증
+     * @param generatedFilename 생성된 파일 이름
+     * @return true / false
+     */
+    private boolean isFilenameExists(String generatedFilename) {
+        return imageInfoRepository.findByUploadFilename(generatedFilename).isPresent();
+    }
+}

--- a/src/main/java/com/toucheese/image/service/ImageService.java
+++ b/src/main/java/com/toucheese/image/service/ImageService.java
@@ -3,7 +3,6 @@ package com.toucheese.image.service;
 import static com.toucheese.image.util.FilenameUtil.extractFileExtension;
 import static com.toucheese.image.util.MetadataUtil.createMetadata;
 
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.toucheese.global.exception.ToucheeseBadRequestException;
 import com.toucheese.global.exception.ToucheeseInternalServerErrorException;
 import com.toucheese.image.entity.ImageInfo;
@@ -14,11 +13,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-@Service
+@Service @Slf4j
 @RequiredArgsConstructor
 public class ImageService {
 
@@ -33,7 +33,7 @@ public class ImageService {
      * @param filename 파일 이름
      */
     public void uploadExistingImage(HttpServletRequest request, String filename) {
-        uploadImage(request, filename, createMetadata(request));
+        uploadImage(request, filename);
     }
 
     /**
@@ -49,7 +49,7 @@ public class ImageService {
             ImageInfo imageInfo = imageInfoService.createImageInfo(filename);
             String extension = extractFileExtension(Objects.requireNonNull(filename));
 
-            uploadImage(uploadFile, imageInfo.getUploadFilename() + extension, createMetadata(uploadFile));
+            uploadImage(uploadFile, imageInfo.getUploadFilename() + extension);
 
             switch (imageType) {
                 case STUDIO -> imageFacade.saveStudioImage(entityId, imageInfo, extension);
@@ -66,25 +66,26 @@ public class ImageService {
      * @param request 요청 정보 (InputStream, Metadata)
      * @param filename 업로드 할 파일 이름
      */
-    private void uploadImage(HttpServletRequest request, String filename, ObjectMetadata metadata) {
+    private void uploadImage(HttpServletRequest request, String filename) {
         try {
-            s3ImageUtil.uploadImage(filename, request.getInputStream(), metadata);
+            s3ImageUtil.uploadImage(filename, request.getInputStream(), createMetadata(request));
         } catch (IOException e) {
-            throw new ToucheeseInternalServerErrorException(e.getMessage());
+            log.error("이미지 업로드 실패 - 파일명: {}", filename, e);
+            throw new ToucheeseInternalServerErrorException("이미지 업로드 중 오류 발생: " + e.getMessage());
         }
     }
 
     /**
      * 요청받은 이미지 업로드
-     * @param uploadFile 업로드 요청 파일
+     * @param uploadFile 업로드 요청 파일 (inputStream, uploadFile)
      * @param filename 생성된 파일 이름
-     * @param metadata 생성된 메타데이터
      */
-    private void uploadImage(MultipartFile uploadFile, String filename, ObjectMetadata metadata) {
+    private void uploadImage(MultipartFile uploadFile, String filename) {
         try {
-            s3ImageUtil.uploadImage(filename, uploadFile.getInputStream(), metadata);
+            s3ImageUtil.uploadImage(filename, uploadFile.getInputStream(), createMetadata(uploadFile));
         } catch (IOException e) {
-            throw new ToucheeseInternalServerErrorException(e.getMessage());
+            log.error("이미지 업로드 실패 - 파일명: {}", filename, e);
+            throw new ToucheeseInternalServerErrorException("이미지 업로드 중 오류 발생: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/toucheese/image/service/ImageService.java
+++ b/src/main/java/com/toucheese/image/service/ImageService.java
@@ -63,7 +63,7 @@ public class ImageService {
 
     /**
      * 요청받은 이미지 업로드
-     * @param request 요청 정보 (InputStream, Metadata)
+     * @param request 요청 정보
      * @param filename 업로드 할 파일 이름
      */
     private void uploadImage(HttpServletRequest request, String filename) {
@@ -77,7 +77,7 @@ public class ImageService {
 
     /**
      * 요청받은 이미지 업로드
-     * @param uploadFile 업로드 요청 파일 (inputStream, uploadFile)
+     * @param uploadFile 업로드 요청 파일
      * @param filename 생성된 파일 이름
      */
     private void uploadImage(MultipartFile uploadFile, String filename) {

--- a/src/main/java/com/toucheese/image/service/ImageService.java
+++ b/src/main/java/com/toucheese/image/service/ImageService.java
@@ -2,14 +2,10 @@ package com.toucheese.image.service;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.toucheese.global.exception.ToucheeseInternalServerErrorException;
-import com.toucheese.image.entity.FacilityImage;
-import com.toucheese.image.entity.ImageType;
-import com.toucheese.image.entity.ReviewImage;
-import com.toucheese.image.entity.StudioImage;
+import com.toucheese.image.entity.*;
 import com.toucheese.image.repository.FacilityImageRepository;
 import com.toucheese.image.repository.ReviewImageRepository;
 import com.toucheese.image.repository.StudioImageRepository;
-import com.toucheese.image.util.FilenameUtil;
 import com.toucheese.image.util.S3ImageUtil;
 import com.toucheese.review.entity.Review;
 import com.toucheese.review.service.ReviewService;
@@ -17,19 +13,23 @@ import com.toucheese.studio.entity.Studio;
 import com.toucheese.studio.service.StudioService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.function.BiFunction;
+import java.util.List;
+import java.util.Objects;
+
+import static com.toucheese.image.util.FilenameUtil.buildFilePath;
+import static com.toucheese.image.util.FilenameUtil.extractFileExtension;
+import static com.toucheese.image.util.MetadataUtil.createMetadata;
 
 @Service
 @RequiredArgsConstructor
 public class ImageService {
 
     private final S3ImageUtil s3ImageUtil;
-    private final FilenameUtil filenameUtil;
 
     private final StudioService studioService;
     private final StudioImageRepository studioImageRepository;
@@ -39,6 +39,8 @@ public class ImageService {
 
     private final FacilityImageRepository facilityImageRepository;
 
+    private final ImageInfoService imageInfoService;
+
     private static final String RESIZED_EXTENSION = ".webp";
 
     /**
@@ -47,80 +49,64 @@ public class ImageService {
      * @param filename 파일 이름
      */
     public void uploadExistingImage(HttpServletRequest request, String filename) {
-        uploadImage(request, filename);
+        uploadImage(request, filename, createMetadata(request));
     }
 
+    /**
+     * 새 이미지 업로드하기 위한 메서드
+     * @param uploadFiles 업로드 할 파일 목록
+     * @param entityId 연관관계 객체 아이디
+     * @param imageType 이미지 타입
+     */
     @Transactional
-    public void uploadImageWithDetails(HttpServletRequest request, String filename, Long entityId, ImageType imageType) {
-        String randomFilename = generateRandomFilename(imageType);
-        String extension = filenameUtil.extractFileExtension(filename);
-        uploadImage(request, randomFilename + extension);
+    public void uploadImageWithDetails(List<MultipartFile> uploadFiles, Long entityId, ImageType imageType) {
+        for (MultipartFile uploadFile : uploadFiles) {
+            String filename = uploadFile.getOriginalFilename();
+            ImageInfo imageInfo = imageInfoService.createImageInfo(filename);
+            String extension = extractFileExtension(Objects.requireNonNull(filename));
 
-        switch (imageType) {
-            case STUDIO -> saveStudioImage(entityId, filename, randomFilename, extension);
-            case REVIEW -> saveReviewImage(entityId, filename, randomFilename, extension);
-            case FACILITY -> saveFacilityImage(entityId, filename, randomFilename, extension);
-            default -> throw new IllegalArgumentException("Unsupported image type: " + imageType);
+            uploadImage(uploadFile, imageInfo.getUploadFilename() + extension, createMetadata(uploadFile));
+
+            switch (imageType) {
+                case STUDIO -> saveStudioImage(entityId, imageInfo, extension);
+                case REVIEW -> saveReviewImage(entityId, imageInfo, extension);
+                case FACILITY -> saveFacilityImage(entityId, imageInfo, extension);
+                default -> throw new IllegalArgumentException("Unsupported image type: " + imageType);
+            }
         }
     }
 
-    private void saveStudioImage(Long studioId, String filename, String randomFilename, String extension) {
+    private void saveStudioImage(Long studioId, ImageInfo imageInfo, String extension) {
         Studio studio = studioService.findStudioById(studioId);
         StudioImage studioImage = StudioImage.builder()
                 .studio(studio)
-                .filename(filename)
-                .uploadFilename(randomFilename)
-                .originalPath(filenameUtil.buildFilePath(randomFilename, extension))
-                .resizedPath(filenameUtil.buildFilePath(randomFilename, RESIZED_EXTENSION))
+                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
+                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
+                .imageInfo(imageInfo)
                 .build();
         studioImageRepository.save(studioImage);
     }
 
-    private void saveReviewImage(Long reviewId, String filename, String randomFilename, String extension) {
+    private void saveReviewImage(Long reviewId, ImageInfo imageInfo, String extension) {
         Review review = reviewService.findReviewById(reviewId);
         ReviewImage reviewImage = ReviewImage.builder()
                 .review(review)
-                .filename(filename)
-                .uploadFilename(randomFilename)
-                .originalPath(filenameUtil.buildFilePath(randomFilename, extension))
-                .resizedPath(filenameUtil.buildFilePath(randomFilename, RESIZED_EXTENSION))
+                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
+                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
+                .imageInfo(imageInfo)
                 .build();
         reviewImageRepository.save(reviewImage);
     }
 
-    private void saveFacilityImage(Long studioId, String filename, String randomFilename, String extension) {
+    private void saveFacilityImage(Long studioId, ImageInfo imageInfo, String extension) {
         Studio studio = studioService.findStudioById(studioId);
         FacilityImage facilityImage = FacilityImage.builder()
                 .studio(studio)
-                .filename(filename)
-                .uploadFilename(randomFilename)
-                .originalPath(filenameUtil.buildFilePath(randomFilename, extension))
-                .resizedPath(filenameUtil.buildFilePath(randomFilename, RESIZED_EXTENSION))
+                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
+                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
+                .imageInfo(imageInfo)
                 .build();
         facilityImageRepository.save(facilityImage);
-    }
-
-    /**
-     * 생성된 랜덤 파일명 중복 체크
-     * @return 중복되지 않는 랜덤 파일명
-     */
-    @Transactional(readOnly = true)
-    public String generateRandomFilename(ImageType imageType) {
-        String randomFilename;
-
-        do {
-            randomFilename = filenameUtil.generateRandomFileName();
-        } while (isFilenameExists(randomFilename, imageType));
-
-        return randomFilename;
-    }
-
-    private boolean isFilenameExists(String filename, ImageType imageType) {
-        return switch (imageType) {
-            case STUDIO -> studioImageRepository.findByUploadFilename(filename).isPresent();
-            case REVIEW -> reviewImageRepository.findByUploadFilename(filename).isPresent();
-            case FACILITY -> facilityImageRepository.findByUploadFilename(filename).isPresent();
-        };
     }
 
     /**
@@ -128,25 +114,25 @@ public class ImageService {
      * @param request 요청 정보 (InputStream, Metadata)
      * @param filename 업로드 할 파일 이름
      */
-    private void uploadImage(HttpServletRequest request, String filename) {
+    private void uploadImage(HttpServletRequest request, String filename, ObjectMetadata metadata) {
         try {
-            ObjectMetadata metadata = createMetadata(request);
-            s3ImageUtil.uploadImage(metadata, filename, request.getInputStream());
+            s3ImageUtil.uploadImage(filename, request.getInputStream(), metadata);
         } catch (IOException e) {
             throw new ToucheeseInternalServerErrorException(e.getMessage());
         }
     }
 
     /**
-     * 요청으로부터 ObjectMetadata를 생성
-     * @param request 요청 정보
-     * @return 생성된 ObjectMetadata
+     * 요청받은 이미지 업로드
+     * @param uploadFile 업로드 요청 파일
+     * @param filename 생성된 파일 이름
+     * @param metadata 생성된 메타데이터
      */
-    private ObjectMetadata createMetadata(HttpServletRequest request) {
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType(request.getContentType());
-        metadata.setContentLength(request.getContentLength());
-        return metadata;
+    private void uploadImage(MultipartFile uploadFile, String filename, ObjectMetadata metadata) {
+        try {
+            s3ImageUtil.uploadImage(filename, uploadFile.getInputStream(), metadata);
+        } catch (IOException e) {
+            throw new ToucheeseInternalServerErrorException(e.getMessage());
+        }
     }
-
 }

--- a/src/main/java/com/toucheese/image/service/ImageService.java
+++ b/src/main/java/com/toucheese/image/service/ImageService.java
@@ -1,32 +1,22 @@
 package com.toucheese.image.service;
 
+import static com.toucheese.image.util.FilenameUtil.extractFileExtension;
+import static com.toucheese.image.util.MetadataUtil.createMetadata;
+
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.toucheese.global.exception.ToucheeseBadRequestException;
 import com.toucheese.global.exception.ToucheeseInternalServerErrorException;
-import com.toucheese.image.entity.*;
-import com.toucheese.image.repository.FacilityImageRepository;
-import com.toucheese.image.repository.QuestionImageRepository;
-import com.toucheese.image.repository.ReviewImageRepository;
-import com.toucheese.image.repository.StudioImageRepository;
+import com.toucheese.image.entity.ImageInfo;
+import com.toucheese.image.entity.ImageType;
 import com.toucheese.image.util.S3ImageUtil;
-import com.toucheese.question.entity.Question;
-import com.toucheese.question.service.QuestionReadService;
-import com.toucheese.review.entity.Review;
-import com.toucheese.review.service.ReviewService;
-import com.toucheese.studio.entity.Studio;
-import com.toucheese.studio.service.StudioService;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-
-import static com.toucheese.image.util.FilenameUtil.buildFilePath;
-import static com.toucheese.image.util.FilenameUtil.extractFileExtension;
-import static com.toucheese.image.util.MetadataUtil.createMetadata;
 
 @Service
 @RequiredArgsConstructor
@@ -34,20 +24,8 @@ public class ImageService {
 
     private final S3ImageUtil s3ImageUtil;
 
-    private final StudioService studioService;
-    private final StudioImageRepository studioImageRepository;
-
-    private final ReviewService reviewService;
-    private final ReviewImageRepository reviewImageRepository;
-
-    private final FacilityImageRepository facilityImageRepository;
-
-    private final QuestionReadService questionReadService;
-    private final QuestionImageRepository questionImageRepository;
-
+    private final ImageFacade imageFacade;
     private final ImageInfoService imageInfoService;
-
-    private static final String RESIZED_EXTENSION = ".webp";
 
     /**
      * 기존 이미지를 업로드하기 위한 메서드
@@ -74,57 +52,13 @@ public class ImageService {
             uploadImage(uploadFile, imageInfo.getUploadFilename() + extension, createMetadata(uploadFile));
 
             switch (imageType) {
-                case STUDIO -> saveStudioImage(entityId, imageInfo, extension);
-                case REVIEW -> saveReviewImage(entityId, imageInfo, extension);
-                case FACILITY -> saveFacilityImage(entityId, imageInfo, extension);
-                case QUESTION -> saveQuestionImage(entityId, imageInfo, extension);
-                default -> throw new IllegalArgumentException("Unsupported image type: " + imageType);
+                case STUDIO -> imageFacade.saveStudioImage(entityId, imageInfo, extension);
+                case REVIEW -> imageFacade.saveReviewImage(entityId, imageInfo, extension);
+                case FACILITY -> imageFacade.saveFacilityImage(entityId, imageInfo, extension);
+                case QUESTION -> imageFacade.saveQuestionImage(entityId, imageInfo, extension);
+                default -> throw new ToucheeseBadRequestException(imageType + ": 존재하지 않는 형식 입니다.");
             }
         }
-    }
-
-    private void saveStudioImage(Long studioId, ImageInfo imageInfo, String extension) {
-        Studio studio = studioService.findStudioById(studioId);
-        StudioImage studioImage = StudioImage.builder()
-                .studio(studio)
-                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
-                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
-                .imageInfo(imageInfo)
-                .build();
-        studioImageRepository.save(studioImage);
-    }
-
-    private void saveReviewImage(Long reviewId, ImageInfo imageInfo, String extension) {
-        Review review = reviewService.findReviewById(reviewId);
-        ReviewImage reviewImage = ReviewImage.builder()
-                .review(review)
-                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
-                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
-                .imageInfo(imageInfo)
-                .build();
-        reviewImageRepository.save(reviewImage);
-    }
-
-    private void saveFacilityImage(Long studioId, ImageInfo imageInfo, String extension) {
-        Studio studio = studioService.findStudioById(studioId);
-        FacilityImage facilityImage = FacilityImage.builder()
-                .studio(studio)
-                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
-                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
-                .imageInfo(imageInfo)
-                .build();
-        facilityImageRepository.save(facilityImage);
-    }
-
-    private void saveQuestionImage(Long questionId, ImageInfo imageInfo, String extension) {
-        Question question = questionReadService.findQuestionById(questionId);
-        QuestionImage questionImage = QuestionImage.builder()
-                .question(question)
-                .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))
-                .resizedPath(buildFilePath(imageInfo.getUploadFilename(), RESIZED_EXTENSION))
-                .imageInfo(imageInfo)
-                .build();
-        questionImageRepository.save(questionImage);
     }
 
     /**

--- a/src/main/java/com/toucheese/image/util/FilenameUtil.java
+++ b/src/main/java/com/toucheese/image/util/FilenameUtil.java
@@ -1,10 +1,7 @@
 package com.toucheese.image.util;
 
-import org.springframework.stereotype.Component;
-
 import java.security.SecureRandom;
 
-@Component
 public class FilenameUtil {
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     private static final int FILE_NAME_LENGTH = 7;
@@ -14,7 +11,7 @@ public class FilenameUtil {
      * 랜덤 파일명 생성 메서드
      * @return 생성된 랜덤 파일명
      */
-    public String generateRandomFileName() {
+    public static String generateRandomFileName() {
         StringBuilder sb = new StringBuilder(FILE_NAME_LENGTH);
         for (int i = 0; i < FILE_NAME_LENGTH; i++) {
             int index = random.nextInt(CHARACTERS.length());
@@ -29,7 +26,7 @@ public class FilenameUtil {
      * @param extension 파일 확장자
      * @return 파일 경로
      */
-    public String buildFilePath(String filename, String extension) {
+    public static String buildFilePath(String filename, String extension) {
         return "/" + filename + extension;
     }
 
@@ -38,7 +35,7 @@ public class FilenameUtil {
      * @param filename 파일 이름
      * @return 확장자
      */
-    public String extractFileExtension(String filename) {
+    public static String extractFileExtension(String filename) {
         return filename.substring(filename.lastIndexOf('.'));
     }
 }

--- a/src/main/java/com/toucheese/image/util/MetadataUtil.java
+++ b/src/main/java/com/toucheese/image/util/MetadataUtil.java
@@ -1,0 +1,33 @@
+package com.toucheese.image.util;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+public class MetadataUtil {
+
+    /**
+     * 요청으로부터 ObjectMetadata를 생성
+     * @param request 요청 정보
+     * @return 생성된 ObjectMetadata
+     */
+    public static ObjectMetadata createMetadata(HttpServletRequest request) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(request.getContentType());
+        metadata.setContentLength(request.getContentLength());
+        return metadata;
+    }
+
+    /**
+     * 요청 파일로부터 ObjectMetadata를 생성
+     * @param uploadFile 파일 정보
+     * @return 생성된 ObjectMetadata
+     */
+    public static ObjectMetadata createMetadata(MultipartFile uploadFile) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(uploadFile.getContentType());
+        metadata.setContentLength(uploadFile.getSize());
+        return metadata;
+    }
+
+}

--- a/src/main/java/com/toucheese/image/util/S3ImageUtil.java
+++ b/src/main/java/com/toucheese/image/util/S3ImageUtil.java
@@ -30,13 +30,20 @@ public class S3ImageUtil {
      * S3에 이미지 업로드
      * @param metadata 요청 메타데이터
      * @param filename 파일 이름
-     * @param stream InputStream (파일 전송)
+     * @param stream 파일 전송을 위한 inputStream
      */
     public void uploadImage(String filename, InputStream stream, ObjectMetadata metadata) {
         s3Config.amazonS3Client()
                 .putObject(createPutObjectRequest(filename, stream, metadata));
     }
 
+    /**
+     * S3 이미지 업로드 요청 객체 생성
+     * @param filename 파일이름
+     * @param stream 파일 전송을 위한 inputStream
+     * @param metadata 메타데이터
+     * @return S3 요청 객체
+     */
     public PutObjectRequest createPutObjectRequest(String filename, InputStream stream, ObjectMetadata metadata) {
         return new PutObjectRequest(
                 bucketName + uploadPath,

--- a/src/main/java/com/toucheese/image/util/S3ImageUtil.java
+++ b/src/main/java/com/toucheese/image/util/S3ImageUtil.java
@@ -1,12 +1,15 @@
 package com.toucheese.image.util;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.toucheese.global.config.S3Config;
 import jakarta.servlet.ServletInputStream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
 
 @Component @Getter
 @RequiredArgsConstructor
@@ -29,14 +32,18 @@ public class S3ImageUtil {
      * @param filename 파일 이름
      * @param stream InputStream (파일 전송)
      */
-    public void uploadImage(ObjectMetadata metadata, String filename, ServletInputStream stream) {
+    public void uploadImage(String filename, InputStream stream, ObjectMetadata metadata) {
         s3Config.amazonS3Client()
-                .putObject(
-                        bucketName + uploadPath,
-                        filename,
-                        stream,
-                        metadata
-                );
+                .putObject(createPutObjectRequest(filename, stream, metadata));
+    }
+
+    public PutObjectRequest createPutObjectRequest(String filename, InputStream stream, ObjectMetadata metadata) {
+        return new PutObjectRequest(
+                bucketName + uploadPath,
+                filename,
+                stream,
+                metadata
+        );
     }
 
 }

--- a/src/main/java/com/toucheese/question/controller/QuestionController.java
+++ b/src/main/java/com/toucheese/question/controller/QuestionController.java
@@ -4,20 +4,23 @@ import com.toucheese.global.data.ApiResponse;
 import com.toucheese.question.dto.QuestionDetailResponse;
 import com.toucheese.question.dto.QuestionRequest;
 import com.toucheese.question.dto.QuestionResponse;
-import com.toucheese.question.entity.Question;
 import com.toucheese.question.service.QuestionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
-
-import javax.print.attribute.standard.PrinterName;
-import java.security.Principal;
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,8 +42,8 @@ public class QuestionController {
         """
     )
     public ResponseEntity<?> createQuestion(@RequestBody QuestionRequest questionRequest, Principal principal) {
-        Question question = questionService.createQuestion(questionRequest, principal);
-        return ApiResponse.createdSuccess("문의하기글이 성공적으로 생성되었습니다.");
+        questionService.createQuestion(questionRequest, principal);
+        return ApiResponse.createdSuccess("문의하기 글이 성공적으로 생성되었습니다.");
     }
 
     @GetMapping("/{questionId}")
@@ -60,7 +63,7 @@ public class QuestionController {
         """
     )
     public ResponseEntity<QuestionDetailResponse> getQuestionById(@PathVariable Long questionId, Principal principal){
-        QuestionDetailResponse response = questionService.findQuestionDetailById(questionId, principal);
+        QuestionDetailResponse response = questionService.findQuestionDetailById(questionId);
         return ApiResponse.getObjectSuccess(response);
     }
 
@@ -93,8 +96,8 @@ public class QuestionController {
         """
     )
     public ResponseEntity<?> updateQuestion(@PathVariable Long questionId, @RequestBody QuestionRequest questionRequest, Principal principal) {
-        QuestionResponse response = questionService.updateQuestion(questionId, questionRequest, principal);
-        return ApiResponse.updatedSuccess("문의하기글이 성공적으로 수정되었습니다.");
+        questionService.updateQuestion(questionId, questionRequest, principal);
+        return ApiResponse.updatedSuccess("문의하기 글이 성공적으로 수정되었습니다.");
     }
 
     // 게시글 삭제
@@ -108,6 +111,6 @@ public class QuestionController {
     )
     public ResponseEntity<?> deleteQuestion(@PathVariable Long questionId, Principal principal) {
         questionService.deleteQuestion(questionId, principal);
-        return ApiResponse.deletedSuccess("문의하기글이 성공적으로 삭제되었습니다.");
+        return ApiResponse.deletedSuccess("문의하기 글이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/toucheese/question/dto/QuestionDetailResponse.java
+++ b/src/main/java/com/toucheese/question/dto/QuestionDetailResponse.java
@@ -2,6 +2,7 @@ package com.toucheese.question.dto;
 
 import com.toucheese.question.entity.AnswerStatus;
 import com.toucheese.question.entity.Question;
+import java.util.List;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -13,9 +14,10 @@ public record QuestionDetailResponse (
         String content,
         LocalDate createDate,
         AnswerResponse answerResponse,
-        AnswerStatus answerStatus
+        AnswerStatus answerStatus,
+        List<String> imageUrls
 ){
-    public static QuestionDetailResponse of(Question question) {
+    public static QuestionDetailResponse of(Question question, String baseUrl) {
         AnswerResponse answerResponse = null;
         if (question.getAnswer() != null && question.getAnswerStatus() == AnswerStatus.답변완료) {
             answerResponse = AnswerResponse.of(question.getAnswer());
@@ -27,6 +29,10 @@ public record QuestionDetailResponse (
                 .createDate(question.getCreateDate())
                 .answerResponse(answerResponse)
                 .answerStatus(question.getAnswerStatus())
+                .imageUrls(question.getQuestionImages().stream()
+                        .map(questionImage -> baseUrl + questionImage.getResizedPath())
+                        .toList()
+                )
                 .build();
     }
 }

--- a/src/main/java/com/toucheese/question/dto/QuestionResponse.java
+++ b/src/main/java/com/toucheese/question/dto/QuestionResponse.java
@@ -2,6 +2,7 @@ package com.toucheese.question.dto;
 
 import com.toucheese.question.entity.AnswerStatus;
 import com.toucheese.question.entity.Question;
+import java.util.List;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -12,15 +13,20 @@ public record QuestionResponse (
         String title,
         String content,
         LocalDate createDate,
-        AnswerStatus answerStatus
+        AnswerStatus answerStatus,
+        List<String> imageUrls
 ){
-    public static QuestionResponse of(Question question) {
+    public static QuestionResponse of(Question question, String baseUrl) {
         return QuestionResponse.builder()
                 .id(question.getId())
                 .title(question.getTitle())
                 .content(question.getContent())
                 .createDate(question.getCreateDate())
                 .answerStatus(question.getAnswerStatus())
+                .imageUrls(question.getQuestionImages().stream()
+                        .map(questionImage -> baseUrl + questionImage.getResizedPath())
+                        .toList()
+                )
                 .build();
     }
 }

--- a/src/main/java/com/toucheese/question/entity/Question.java
+++ b/src/main/java/com/toucheese/question/entity/Question.java
@@ -1,8 +1,10 @@
 package com.toucheese.question.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.toucheese.image.entity.QuestionImage;
 import com.toucheese.member.entity.Member;
 import jakarta.persistence.*;
+import java.util.List;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -38,6 +40,9 @@ public class Question {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "answer_id")
     private Answer answer;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "question")
+    private List<QuestionImage> questionImages;
 
     public void update(String title, String content) {
         this.title = title;

--- a/src/main/java/com/toucheese/question/service/QuestionService.java
+++ b/src/main/java/com/toucheese/question/service/QuestionService.java
@@ -1,9 +1,8 @@
 package com.toucheese.question.service;
 
+import com.toucheese.global.config.ImageConfig;
 import com.toucheese.global.util.PageUtils;
-import com.toucheese.global.util.PrincipalUtils;
 import com.toucheese.member.entity.Member;
-import com.toucheese.member.repository.MemberRepository;
 import com.toucheese.question.dto.QuestionDetailResponse;
 import com.toucheese.question.dto.QuestionRequest;
 import com.toucheese.question.dto.QuestionResponse;
@@ -11,22 +10,19 @@ import com.toucheese.question.entity.AnswerStatus;
 import com.toucheese.question.entity.Question;
 import com.toucheese.question.repository.QuestionRepository;
 import com.toucheese.question.util.QuestionUtil;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.security.Principal;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class QuestionService {
+
+    private final ImageConfig imageConfig;
     private final QuestionRepository questionRepository;
-    private final MemberRepository memberRepository;
     private final QuestionReadService questionReadService;
 
     @Transactional
@@ -43,29 +39,30 @@ public class QuestionService {
     }
 
     @Transactional(readOnly = true)
-    public QuestionDetailResponse findQuestionDetailById(Long id, Principal principal) {
+    public QuestionDetailResponse findQuestionDetailById(Long id) {
         Question question = questionReadService.findQuestionById(id);
-        return QuestionDetailResponse .of(question);
+        return QuestionDetailResponse.of(question, imageConfig.getResizedImageBaseUrl());
     }
 
     @Transactional(readOnly = true)
     public Page<QuestionResponse> findQuestions(Principal principal, int page) {
         Member member = questionReadService.findMemberByPrincipal(principal);
         Pageable pageable = PageUtils.createPageable(page);
+
         Page<Question> questions = questionRepository.findAllByMemberId(member.getId(), pageable);
-        return questions.map(QuestionResponse::of);
+        return questions.map(question ->
+                QuestionResponse.of(question, imageConfig.getResizedImageBaseUrl())
+        );
     }
 
     @Transactional
-    public QuestionResponse updateQuestion(Long id, QuestionRequest questionRequest, Principal principal) {
+    public void updateQuestion(Long id, QuestionRequest questionRequest, Principal principal) {
         Question question = questionReadService.findQuestionById(id);
         QuestionUtil.validateMemberAccess(question, principal);
 
-        question.update(
-                questionRequest.title(),
-                questionRequest.content()
-                );
-        return QuestionResponse.of(questionRepository.save(question));
+        question.update(questionRequest.title(), questionRequest.content());
+
+        questionRepository.save(question);
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,10 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  servlet:
+    multipart:
+      max-file-size: 5MB # 한개 파일의 최대 사이즈 (default: 1MB)
+      max-request-size: 25MB # 한개 요청의 최대 사이즈 (default: 10MB)
 
 springdoc:
   api-docs:


### PR DESCRIPTION
### 🎯 이슈
- close #62 

### 📓 작업 내용
- 이미지 업로드 기능 리팩토링
  - [x] v2 버전의 Stream 업로드 방식 => MultipartFile 업로드 방식으로 변경
  - [x] 이미지 파일이름 검증 로직 리팩토링 (테이블 분리)
  - [x] 코드 리팩토링 (퍼사드 패턴 적용으로 책임 분리

---
### ⭐ 참고사항 
이미지 업로드 시 엔드포인트는 requestParam보다 pathVariable이 더 적합하다고 생각하여 변경했습니다.

이름 검증하는 부분이 너무 중복되는 것 같아서 테이블을 분리하게 되었습니다. (ERD cloud에 변경 해두었습니다)
이후 테이블을 정리해서 덤프뜨는 작업을 진행하겠습니다.
본 기능이 배포되기 이전에 말씀해주시면 DB를 갈아끼우는 작업 진행하려고 합니다.

퍼사드 패턴을 적용했습니다.
ImageService 내 기능이 많아짐으로써 책임이 너무 과중된다고 생각하였고, 의존성 주입이 너무 많아져 결합도가 높아보였습니다.
이를 ImageFacade로 분리하여 문제가 된다고 생각했던 저장로직을 분리하여 책임을 분리하고 결합도를 좀 더 낮췄습니다.