### PR TITLE
[Image] 문의, 리뷰 이미지 업로드 기능 통합

### DIFF
--- a/src/main/java/com/toucheese/image/service/ImageFacade.java
+++ b/src/main/java/com/toucheese/image/service/ImageFacade.java
@@ -1,12 +1,6 @@
 package com.toucheese.image.service;
 
-import static com.toucheese.image.util.FilenameUtil.buildFilePath;
-
-import com.toucheese.image.entity.FacilityImage;
-import com.toucheese.image.entity.ImageInfo;
-import com.toucheese.image.entity.QuestionImage;
-import com.toucheese.image.entity.ReviewImage;
-import com.toucheese.image.entity.StudioImage;
+import com.toucheese.image.entity.*;
 import com.toucheese.image.repository.FacilityImageRepository;
 import com.toucheese.image.repository.QuestionImageRepository;
 import com.toucheese.image.repository.ReviewImageRepository;
@@ -14,19 +8,21 @@ import com.toucheese.image.repository.StudioImageRepository;
 import com.toucheese.question.entity.Question;
 import com.toucheese.question.service.QuestionReadService;
 import com.toucheese.review.entity.Review;
-import com.toucheese.review.service.ReviewService;
+import com.toucheese.review.service.ReviewQueryService;
 import com.toucheese.studio.entity.Studio;
 import com.toucheese.studio.service.StudioService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.toucheese.image.util.FilenameUtil.buildFilePath;
+
 @Component
 @RequiredArgsConstructor
 public class ImageFacade {
 
     private final StudioService studioService;
-    private final ReviewService reviewService;
+    private final ReviewQueryService reviewQueryService;
     private final QuestionReadService questionReadService;
 
     private final StudioImageRepository studioImageRepository;
@@ -62,7 +58,7 @@ public class ImageFacade {
      */
     @Transactional
     public void saveReviewImage(Long reviewId, ImageInfo imageInfo, String extension) {
-        Review review = reviewService.findReviewById(reviewId);
+        Review review = reviewQueryService.findReviewById(reviewId);
         ReviewImage reviewImage = ReviewImage.builder()
                 .review(review)
                 .originalPath(buildFilePath(imageInfo.getUploadFilename(), extension))

--- a/src/main/java/com/toucheese/member/entity/Member.java
+++ b/src/main/java/com/toucheese/member/entity/Member.java
@@ -7,6 +7,7 @@ import com.toucheese.cart.entity.Cart;
 import com.toucheese.question.entity.Question;
 import com.toucheese.reservation.entity.Reservation;
 
+import com.toucheese.review.entity.Review;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -48,5 +49,8 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Question> questions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Review> reviews = new ArrayList<>();
 
 }

--- a/src/main/java/com/toucheese/question/controller/QuestionController.java
+++ b/src/main/java/com/toucheese/question/controller/QuestionController.java
@@ -12,15 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -41,7 +33,10 @@ public class QuestionController {
         }
         """
     )
-    public ResponseEntity<?> createQuestion(@RequestBody QuestionRequest questionRequest, Principal principal) {
+    public ResponseEntity<?> createQuestion(
+            @ModelAttribute QuestionRequest questionRequest,
+            Principal principal
+    ) {
         questionService.createQuestion(questionRequest, principal);
         return ApiResponse.createdSuccess("문의하기 글이 성공적으로 생성되었습니다.");
     }

--- a/src/main/java/com/toucheese/question/dto/QuestionRequest.java
+++ b/src/main/java/com/toucheese/question/dto/QuestionRequest.java
@@ -3,18 +3,16 @@ package com.toucheese.question.dto;
 import com.toucheese.question.entity.AnswerStatus;
 import com.toucheese.question.entity.Question;
 import lombok.Builder;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 public record QuestionRequest (
         String title,
-        String content
+        String content,
+        List<MultipartFile> uploadFiles
 ){
-    public static QuestionRequest of(Question question) {
-        return QuestionRequest.builder()
-                .title(question.getTitle())
-                .content(question.getContent())
-                .build();
-    }
+
 }

--- a/src/main/java/com/toucheese/question/service/QuestionService.java
+++ b/src/main/java/com/toucheese/question/service/QuestionService.java
@@ -2,6 +2,8 @@ package com.toucheese.question.service;
 
 import com.toucheese.global.config.ImageConfig;
 import com.toucheese.global.util.PageUtils;
+import com.toucheese.image.entity.ImageType;
+import com.toucheese.image.service.ImageService;
 import com.toucheese.member.entity.Member;
 import com.toucheese.question.dto.QuestionDetailResponse;
 import com.toucheese.question.dto.QuestionRequest;
@@ -24,9 +26,10 @@ public class QuestionService {
     private final ImageConfig imageConfig;
     private final QuestionRepository questionRepository;
     private final QuestionReadService questionReadService;
+    private final ImageService imageService;
 
     @Transactional
-    public Question createQuestion(QuestionRequest questionRequest, Principal principal) {
+    public void createQuestion(QuestionRequest questionRequest, Principal principal) {
         Member member = questionReadService.findMemberByPrincipal(principal);
         Question question = Question.builder()
                 .title(questionRequest.title())
@@ -35,7 +38,9 @@ public class QuestionService {
                 .answerStatus(AnswerStatus.답변대기)
                 .build();
 
-        return questionRepository.save(question);
+        question = questionRepository.save(question);
+
+        imageService.uploadImageWithDetails(questionRequest.uploadFiles(), question.getId(), ImageType.QUESTION);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/toucheese/review/controller/ReviewController.java
+++ b/src/main/java/com/toucheese/review/controller/ReviewController.java
@@ -1,19 +1,20 @@
 package com.toucheese.review.controller;
 
 import com.toucheese.global.data.ApiResponse;
+import com.toucheese.global.util.PrincipalUtils;
 import com.toucheese.review.dto.ReviewDetailResponse;
+import com.toucheese.review.dto.ReviewRequest;
 import com.toucheese.review.dto.ReviewResponse;
-import com.toucheese.review.service.ReviewService;
+import com.toucheese.review.service.ReviewQueryService;
+import com.toucheese.review.service.ReviewCommandService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.List;
 
 @RestController
@@ -21,23 +22,38 @@ import java.util.List;
 @RequestMapping("/v1/studios/{studioId}")
 @Tag(name = "리뷰 API", description = "스튜디오 리뷰 목록 조회, 리뷰 상세 조회, 상품별 리뷰 조회")
 public class ReviewController {
-    private final ReviewService reviewService;
+
+    private final ReviewCommandService reviewCommandService;
+    private final ReviewQueryService reviewQueryService;
 
     @GetMapping("/reviews")
     @Operation(summary = "스튜디오 리뷰 목록 조회", description = "리뷰 탭 클릭 시 해당 스튜디오 리뷰 전체 조회")
     public ResponseEntity<List<ReviewResponse>> getStudioReviews(@PathVariable("studioId") Long studioId) {
-        return ApiResponse.getObjectSuccess(reviewService.getReviewsByStudioId(studioId));
+        return ApiResponse.getObjectSuccess(reviewQueryService.getReviewsByStudioId(studioId));
     }
 
     @GetMapping("/reviews/{reviewId}")
     @Operation(summary = "특정 리뷰 상세 조회", description = "리뷰 사진 클릭 시 해당 리뷰 조회")
     public ResponseEntity<ReviewDetailResponse> findStudioReviewDetail(@PathVariable("reviewId") Long reviewId) {
-        return ApiResponse.getObjectSuccess(reviewService.findReviewDetailById(reviewId));
+        return ApiResponse.getObjectSuccess(reviewQueryService.findReviewDetailById(reviewId));
     }
 
     @GetMapping("/products/{productId}/reviews")
     @Operation(summary = "특정 상품 리뷰 목록 조회", description = "상품 리뷰 클릭시 해당 상품 리뷰 조회")
     public ResponseEntity<List<ReviewResponse>> getProductReviews(@PathVariable("productId") Long productId) {
-        return ApiResponse.getObjectSuccess(reviewService.getReviewsByProductId(productId));
+        return ApiResponse.getObjectSuccess(reviewQueryService.getReviewsByProductId(productId));
+    }
+
+    @PostMapping("/products/{productId}/reviews")
+    @Operation(summary = "스튜디오 상품 리뷰 작성", description = "스튜디오 상품 리뷰 작성")
+    public ResponseEntity<?> createReview(
+            @ModelAttribute ReviewRequest reviewRequest,
+            @PathVariable("studioId") Long studioId,
+            @PathVariable("productId") Long productId,
+            Principal principal
+    ) {
+        Long memberId = PrincipalUtils.extractMemberId(principal);
+        reviewCommandService.createReview(reviewRequest, memberId, studioId, productId);
+        return ApiResponse.createdSuccess("리뷰 글이 성공적으로 작성되었습니다.");
     }
 }

--- a/src/main/java/com/toucheese/review/dto/ReviewRequest.java
+++ b/src/main/java/com/toucheese/review/dto/ReviewRequest.java
@@ -1,0 +1,33 @@
+package com.toucheese.review.dto;
+
+import com.toucheese.member.entity.Member;
+import com.toucheese.product.entity.Product;
+import com.toucheese.review.entity.Review;
+import com.toucheese.studio.entity.Studio;
+import lombok.Builder;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Builder
+public record ReviewRequest(
+        String content,
+        Float rating,
+        List<MultipartFile> uploadFiles
+){
+
+    public static Review toEntity(
+            ReviewRequest reviewRequest,
+            Member member,
+            Studio studio,
+            Product product
+    ) {
+        return Review.builder()
+                .content(reviewRequest.content)
+                .rating(reviewRequest.rating)
+                .member(member)
+                .studio(studio)
+                .product(product)
+                .build();
+    }
+}

--- a/src/main/java/com/toucheese/review/entity/Review.java
+++ b/src/main/java/com/toucheese/review/entity/Review.java
@@ -3,6 +3,7 @@ package com.toucheese.review.entity;
 import java.util.List;
 
 import com.toucheese.image.entity.ReviewImage;
+import com.toucheese.member.entity.Member;
 import com.toucheese.product.entity.Product;
 import com.toucheese.studio.entity.Studio;
 
@@ -17,6 +18,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,6 +44,19 @@ public class Review {
 	@JoinColumn(name = "product_id", nullable = true)
 	private Product product;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
 	@OneToMany(mappedBy = "review", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<ReviewImage> reviewImages;
+
+	@Builder
+	public Review(String content, Float rating, Studio studio, Product product, Member member) {
+		this.content = content;
+		this.rating = rating;
+		this.studio = studio;
+		this.product = product;
+		this.member = member;
+	}
 }

--- a/src/main/java/com/toucheese/review/service/ReviewCommandService.java
+++ b/src/main/java/com/toucheese/review/service/ReviewCommandService.java
@@ -1,0 +1,41 @@
+package com.toucheese.review.service;
+
+import com.toucheese.image.entity.ImageType;
+import com.toucheese.image.service.ImageService;
+import com.toucheese.member.entity.Member;
+import com.toucheese.member.service.MemberService;
+import com.toucheese.product.entity.Product;
+import com.toucheese.product.service.ProductService;
+import com.toucheese.review.dto.ReviewRequest;
+import com.toucheese.review.entity.Review;
+import com.toucheese.review.repository.ReviewRepository;
+import com.toucheese.studio.entity.Studio;
+import com.toucheese.studio.service.StudioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewCommandService {
+
+    private final ReviewRepository reviewRepository;
+
+    private final MemberService memberService;
+    private final StudioService studioService;
+    private final ProductService productService;
+    private final ImageService imageService;
+
+    @Transactional
+    public void createReview(ReviewRequest reviewRequest, Long memberId, Long studioId, Long productId) {
+        Member member = memberService.findMemberById(memberId);
+        Studio studio = studioService.findStudioById(studioId);
+        Product product = productService.findProductById(productId);
+
+        Review review = ReviewRequest.toEntity(reviewRequest, member, studio, product);
+        review = reviewRepository.save(review);
+
+        imageService.uploadImageWithDetails(reviewRequest.uploadFiles(), review.getId(), ImageType.REVIEW);
+    }
+
+}

--- a/src/main/java/com/toucheese/review/service/ReviewQueryService.java
+++ b/src/main/java/com/toucheese/review/service/ReviewQueryService.java
@@ -11,23 +11,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class ReviewService {
+public class ReviewQueryService {
 
     private final ImageConfig imageConfig;
     private final ReviewRepository reviewRepository;
-
-    @Transactional(readOnly = true)
-    public List<ReviewResponse> getReviewsByStudioId(Long studioId) {
-        List<Review> reviews = reviewRepository.findAllByStudioId(studioId);
-
-        return reviews.stream()
-                .map(review -> ReviewResponse.of(review, imageConfig.getResizedImageBaseUrl()))
-                .toList();
-    }
 
     @Transactional(readOnly = true)
     public Review findReviewById(Long reviewId) {
@@ -42,6 +32,15 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
+    public List<ReviewResponse> getReviewsByStudioId(Long studioId) {
+        List<Review> reviews = reviewRepository.findAllByStudioId(studioId);
+
+        return reviews.stream()
+                .map(review -> ReviewResponse.of(review, imageConfig.getResizedImageBaseUrl()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
     public List<ReviewResponse> getReviewsByProductId(Long productId) {
         List<Review> reviews = reviewRepository.findAllByProductId(productId);
 
@@ -49,6 +48,4 @@ public class ReviewService {
                 .map(review -> ReviewResponse.of(review, imageConfig.getResizedImageBaseUrl()))
                 .toList();
     }
-
-
 }

--- a/src/main/java/com/toucheese/studio/dto/StudioDetailResponse.java
+++ b/src/main/java/com/toucheese/studio/dto/StudioDetailResponse.java
@@ -13,7 +13,6 @@ public record StudioDetailResponse(
 	Long id,
 	String name,
 	String profileImage,
-	String description,
 	Float rating,
 	Integer reviewCount,
 	String address,
@@ -28,7 +27,6 @@ public record StudioDetailResponse(
 			.id(studio.getId())
 			.name(studio.getName())
 			.profileImage(baseUrl + studio.getProfileImage())
-			.description(studio.getDescription())
 			.rating(studio.getRating())
 			.reviewCount(studio.getReviews().size())
 			.address(studio.getAddress())

--- a/src/main/java/com/toucheese/studio/entity/Studio.java
+++ b/src/main/java/com/toucheese/studio/entity/Studio.java
@@ -50,9 +50,6 @@ public class Studio {
     private Location location;
 
     @Column(columnDefinition = "TEXT")
-    private String description;
-
-    @Column(columnDefinition = "TEXT")
     private String notice;
 
     @OneToMany(mappedBy = "studio", fetch = FetchType.LAZY, cascade = CascadeType.ALL)


### PR DESCRIPTION
### 🎯 이슈
- close #69 

### 📓 작업 내용
- 문의 작성 시 이미지 업로드 기능 추가
  - [x] 이미지 업로드 기능 추가
- 리뷰 작성 기능 추가
  - [x] 리뷰 작성 기능 구현
  - [x] 이미지 업로드 기능 추가
  - [x] 순환 의존성 문제로 CQRS 패턴 적용

---
### ⭐ 참고사항 
이번에 순환 의존성 문제가 발생하게 되어 다른 곳에서도 적용하던 방법인 ReadService와 관련된 [CQRS 패턴](https://docs.aws.amazon.com/ko_kr/prescriptive-guidance/latest/modernization-data-persistence/cqrs-pattern.html) 에 대해서 알게되었습니다.
조금 살펴보면서 적용해 볼 가능성이 있는지에 대해서 고민해보게 되었는데 간단하게 적용하는게 더 확장성있다고 판단하게 되었습니다.

https://www.popit.kr/cqrs-eventsourcing/

위 블로그에서는 3단계의 CQRS 적용을 살펴볼 수 있고, 더 디테일하게 나누자면 아래와 같을 것 같습니다.
- 1단계: Service 레이어에서 Command와 Query 분리.
- 2단계: 읽기와 쓰기를 위한 DTO나 데이터 모델을 분리. + Repository를 분리하고, 읽기 전용 쿼리를 최적화.
- 3단계: 읽기와 쓰기 데이터베이스를 분리(Read Replica 사용).
- 4단계: 이벤트 소싱, 비동기 메시징을 도입하여 완전한 CQRS 구현.

저는 이 중 1단계 요소를 적용하였고 Query(Read)와 Command(Create, Update, Delete)로 분리하였습니다.
향후 2단계까지 같이 적용해보면 좋을 것 같다는 생각이 들었습니다.

CQRS는 MSA의 첫단계라고 말할 만큼 분리에 초점이 맞춰져있고 확장성이 좋은 패턴인 것 같아서 잘 활용하면 좋을 것 같습니다.